### PR TITLE
fix: Used auto_now for last_login in Account model

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -49,7 +49,7 @@ class Account(AbstractBaseUser):
 
     # required
     date_joined     = models.DateTimeField(auto_now_add=True)
-    last_login      = models.DateTimeField(auto_now_add=True)
+    last_login      = models.DateTimeField(auto_now=True)
     is_admin        = models.BooleanField(default=False)
     is_staff        = models.BooleanField(default=False)
     is_active        = models.BooleanField(default=False)


### PR DESCRIPTION
### Changes Made
Modified last_login field in the Account model to use auto_now=True instead of auto_now_add for accurate tracking of user login times.

Stackoverflow link : https://stackoverflow.com/a/61382653/15961087